### PR TITLE
Make grid movement more snappy by buffering input direction

### DIFF
--- a/Player/player.gd
+++ b/Player/player.gd
@@ -20,11 +20,36 @@ var inputDirection = Vector2(0, 0)
 var isMoving = false
 var percentMovedToNextTile = 0.0
 
+# Keep track of the latest direction the player wants to move to
+var latestDirection = null
+
+# Utility mapping from direction to vector
+const MOVEMENTS = {
+	facingDirections.UP: Vector2.UP,
+	facingDirections.LEFT: Vector2.LEFT,
+	facingDirections.RIGHT: Vector2.RIGHT,
+	facingDirections.DOWN: Vector2.DOWN,
+ }
+
 func _ready():
 	animTree.active = true
 	initialPosition = position
 
 func _physics_process(delta):
+	# First we register which direction the player intents to move to
+	if Input.is_action_just_pressed("ui_left"):
+		latestDirection = facingDirections.LEFT
+	elif Input.is_action_just_pressed("ui_right"):
+		latestDirection = facingDirections.RIGHT
+	elif Input.is_action_just_pressed("ui_down"):
+		latestDirection = facingDirections.DOWN
+	elif Input.is_action_just_pressed("ui_up"):
+		latestDirection = facingDirections.UP
+
+	# If they release a button, they cancel their intent
+	if Input.is_action_just_released("ui_up") or Input.is_action_just_released("ui_left") or Input.is_action_just_released("ui_right") or Input.is_action_just_released("ui_down"):
+		latestDirection = null
+		
 	if currentPlayerState == playerStates.TURNING:
 		return
 	elif isMoving == false:
@@ -48,10 +73,16 @@ func change_front_check_position(dir):
 			frontCheckBox.position = Vector2(-16, -16)
 
 func process_player_input():
+
 	if inputDirection.y == 0:
 		inputDirection.x = int(Input.is_action_pressed("ui_right")) - int(Input.is_action_pressed("ui_left"))
 	if inputDirection.x == 0:
 		inputDirection.y = int(Input.is_action_pressed("ui_down")) - int(Input.is_action_pressed("ui_up"))
+
+	# If the player had intent to move, use that instead of the "outdated" inputDirection
+	if latestDirection != null:
+		inputDirection = MOVEMENTS[latestDirection]
+
 	if inputDirection != Vector2.ZERO:
 		animTree.set("parameters/Idle/blend_position", inputDirection)
 		animTree.set("parameters/Walk/blend_position", inputDirection)


### PR DESCRIPTION
As requested by https://old.reddit.com/r/godot/comments/1kiqbfi/need_help_with_adding_topdown_grid_based_movement/

The main idea is to store the last direction the player intended to move to when they just pressed a button, and clear it when they release any button.
Now when processing input, use this stored intent instead of the current held-down buttons if needed.

I wouldn't merge this as-is, as there is a lot of untidy duplicate logic regarding direction and vectors, but it should give you some idea.

Also there is an unrelated bug where your character gets stuck when you turn too quickly, but I'll let you figure that one out :)